### PR TITLE
chore(.github/workflows): actions/setup-node@v3의 cache, node-version-file 옵션 추가

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -13,7 +13,9 @@ jobs:
       - uses: actions/setup-node@v3
         name: 🌳 Setup Node.js
         with:
-          node-version: 18
+          cache: yarn
+          cache-dependency-path: yarn.lock
+          node-version-file: '.nvmrc'
 
       - name: 🏗️ Install Package
         run: |

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -19,7 +19,7 @@ jobs:
 
       - name: 🏗️ Install Package
         run: |
-          yarn
+          yarn install --frozen-lockfile
 
       - name: 📘 Run type check
         run: |


### PR DESCRIPTION
# actions/setup-node@v3 cache, node-version-file 옵션 추가

안녕하세요. 민수님 코드를 보다가 bun관련 작업 보다가 프로젝트에 관심을 갖게되었어요
아래는 제안하고 싶은 부분이 있어 Pull Request로 올려봤어요. 혹시 이렇게 제안하는 게 실례는 아니겠죠??

## actions/setup-node@v3 옵션 사용 제안

- cache: 캐싱을 사용해서 pr의 workflows를 더욱 빠르게 할 수도 있을 거 같아요 ([actions/setup-node 설명](https://github.com/actions/setup-node/blob/main/docs/advanced-usage.md#caching-packages-data))
- node-version-file: .nvmrc로 통일하게 되요 ([actions/setup-node 설명](https://github.com/actions/setup-node/blob/main/docs/advanced-usage.md#node-version-file))